### PR TITLE
Set up CI workflow for Rust tests using GitHub Actions

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -1,0 +1,47 @@
+name: Rust Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose
+      
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose

--- a/README.md
+++ b/README.md
@@ -191,6 +191,17 @@ The tool uses the following process to analyze Python code:
 4. When analyzing impacts, traverse the dependency graph in reverse to find functions that depend on the target function
 5. For visualizations, generate a DOT format representation of the relevant portion of the dependency graph
 
+## Continuous Integration
+
+This project uses GitHub Actions for continuous integration. All tests are automatically run on every pull request to ensure code quality and prevent regressions.
+
+The CI workflow:
+- Builds the project
+- Runs all tests
+- Reports any test failures
+
+You can see the workflow configuration in the `.github/workflows/rust-tests.yml` file.
+
 ## Limitations
 
 - The tool analyzes static code and may not capture all dynamic dependencies


### PR DESCRIPTION
- Added `.github/workflows/rust-tests.yml` file to define the CI pipeline.
- Configured CI to run tests on push and pull request events targeting the `main` branch.
- Included caching for dependencies to optimize build times.
- Updated README with information about the continuous integration workflow.